### PR TITLE
Update refl.hpp

### DIFF
--- a/refl.hpp
+++ b/refl.hpp
@@ -4136,7 +4136,7 @@ namespace refl::detail
 /********************************/
 
 #define REFL_DETAIL_PRIMITIVE(TypeName) \
-    REFL_TYPE(TypeName) \
+    REFL_TYPE(TypeName,) \
     REFL_END
 
     // Char types.


### PR DESCRIPTION
Fix Warning: ISO C++11 requires at least one argument for "..." in variadic marco
Thrown at Macro REFL_TYPE(TypeName) from various REFL_DETAIL_PRIMITIVE()