### PR TITLE
Fixing builds on Apple, with xCode 12.3 and set(CMAKE_CXX_STANDARD 17).

### DIFF
--- a/refl.hpp
+++ b/refl.hpp
@@ -34,6 +34,13 @@
 #include <sstream>
 #include <iomanip> // std::quoted
 
+#if defined(__APPLE__)
+
+#include <memory>
+#include <complex>
+
+#else
+
 namespace std
 {
     template <typename T, typename Deleter>
@@ -48,6 +55,8 @@ namespace std
     template <typename T>
     class complex;
 } // namespace std
+
+#endif
 
 #ifdef _MSC_VER
 // Disable VS warning for "Not enough arguments for macro"


### PR DESCRIPTION
    Without these changes, the Apple specific use of inline namespaces to wrap newer, 'experimental' C++ stdlib features cause compile errors with the forward declares of std::unique_ptr in refl.hpp.

Specifically, this is the error message:

/Users/mh/TransformersTCG_QT/external/src/THIRDPARTY_REFLCPP/refl.hpp:4291:67: error: reference to 'unique_ptr' is ambiguous
        void operator()(std::basic_ostream<CharT>& os, const std::unique_ptr<T, D>& t) const
                                                                  ^
In file included from /Users/mh/TransformersTCG_QT/sources/widgets/mainwindow.cpp:1:
In file included from /Users/mh/TransformersTCG_QT/sources/widgets/mainwindow.h:4:
In file included from /Users/mh/Qt6/6.0.0/clang_64/lib/QtWidgets.framework/Headers/QMainWindow:1:
In file included from /Users/mh/Qt6/6.0.0/clang_64/lib/QtWidgets.framework/Headers/qmainwindow.h:43:
In file included from /Users/mh/Qt6/6.0.0/clang_64/lib/QtWidgets.framework/Headers/qtwidgetsglobal.h:43:
In file included from /Users/mh/Qt6/6.0.0/clang_64/lib/QtGui.framework/Headers/qtguiglobal.h:43:
In file included from /Users/mh/Qt6/6.0.0/clang_64/lib/QtCore.framework/Headers/qglobal.h:126:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:643:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2426:28: note: candidate found by name
      lookup is 'std::__1::unique_ptr'
class _LIBCPP_TEMPLATE_VIS unique_ptr {