### PR TITLE
Refactor CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,16 @@ executors:
   gcc:
     docker:
     - image: teeks99/gcc-ubuntu:10
-      environment: { CXX: g++-10, CC: gcc-10 }
+      environment:
+        CXX: g++-10
+        CC: gcc-10
   clang:
     docker:
     - image: teeks99/clang-ubuntu:5
-      environment: { CXX: clang++-5.0, CC: clang-5.0 }
+      environment:
+        CXX: clang++-5.0
+        CC: clang-5.0
+        CONFIG_FLAGS: -D CMAKE_CXX_EXTENSIONS=OFF
 
 commands:
   add_cmake_apt_repo:
@@ -28,7 +33,7 @@ commands:
     parameters:
       build_type: { type: string }
     steps:
-    - run: cmake -S . -B build -G Ninja
+    - run: cmake -S . -B build -G Ninja $CONFIG_FLAGS
         -D CMAKE_BUILD_TYPE=<<parameters.build_type>>
   build:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,23 @@ executors:
       environment: { CXX: g++-10, CC: gcc-10 }
   clang:
     docker:
-    - image: teeks99/clang-ubuntu:12
-      environment: { CXX: clang++-12, CC: clang-12 }
+    - image: teeks99/clang-ubuntu:5
+      environment: { CXX: clang++-5.0, CC: clang-5.0 }
 
 commands:
+  add_cmake_apt_repo:
+    steps:
+    - run: apt-get update -qq
+    - run: apt-get install -y lsb-release apt-transport-https ca-certificates
+        gnupg software-properties-common wget
+    - run: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc
+        2>/dev/null | gpg --dearmor - > /etc/apt/trusted.gpg.d/kitware.gpg
+    - run: apt-add-repository
+        "deb https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main"
   install_packages:
     steps:
     - run: apt-get update -qq
-    - run: apt-get install -y cmake ninja-build
+    - run: apt-get install -y cmake ninja-build git
   configure:
     parameters:
       build_type: { type: string }
@@ -33,10 +42,13 @@ commands:
 jobs:
   build_latest_cpp17:
     parameters:
-      docker: { type: executor }
+      docker: { type: string }
       build_type: { type: string }
     executor: <<parameters.docker>>
     steps:
+    - when:
+        condition: { equal: [clang, <<parameters.docker>>] }
+        steps: [add_cmake_apt_repo]
     - install_packages
     - checkout
     - configure: { build_type: <<parameters.build_type>> }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,53 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-jobs:
-    build_gcc_latest_cpp17:
-        docker:
-            - image: gcc:latest
-        steps:
-            - checkout
-            - run: |
-                wget https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh \
-                    -q -O /tmp/cmake-install.sh \
-                    && chmod u+x /tmp/cmake-install.sh \
-                    && mkdir /tmp/cmake \
-                    && /tmp/cmake-install.sh --skip-license --prefix=/tmp/cmake \
-                    && rm /tmp/cmake-install.sh
-            - run: CXX=g++ /tmp/cmake/bin/cmake -Drefl-cpp_DEVELOPER_MODE=ON . && make
-            - run: ./test/refl-cpp-test
-    build_clang_latest_cpp17:
-        docker:
-            - image: centos/llvm-toolset-7-centos7:latest
-        steps:
-            - checkout
-            - run: |
-                wget https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh \
-                    -q -O /tmp/cmake-install.sh \
-                    && chmod u+x /tmp/cmake-install.sh \
-                    && mkdir /tmp/cmake \
-                    && /tmp/cmake-install.sh --skip-license --prefix=/tmp/cmake \
-                    && rm /tmp/cmake-install.sh
-            - run: CXX=clang++ /tmp/cmake/bin/cmake -Drefl-cpp_DEVELOPER_MODE=ON . && make
-            - run: ./test/refl-cpp-test
 
-# Orchestrate or schedule a set of jobs
+executors:
+  gcc:
+    docker:
+    - image: teeks99/gcc-ubuntu:10
+      environment: { CXX: g++-10, CC: gcc-10 }
+  clang:
+    docker:
+    - image: teeks99/clang-ubuntu:12
+      environment: { CXX: clang++-12, CC: clang-12 }
+
+commands:
+  install_packages:
+    steps:
+    - run: apt-get update -qq
+    - run: apt-get install -y cmake ninja-build
+  configure:
+    parameters:
+      build_type: { type: string }
+    steps:
+    - run: cmake -S . -B build -G Ninja
+        -D CMAKE_BUILD_TYPE=<<parameters.build_type>>
+  build:
+    steps:
+    - run: cmake --build build
+  test:
+    steps:
+    - run:
+        command: ctest --output-on-failure
+        working_directory: build
+
+jobs:
+  build_latest_cpp17:
+    parameters:
+      docker: { type: executor }
+      build_type: { type: string }
+    executor: <<parameters.docker>>
+    steps:
+    - install_packages
+    - checkout
+    - configure: { build_type: <<parameters.build_type>> }
+    - build
+    - test
+
 workflows:
-    build_and_test:
-        jobs:
-            - build_gcc_latest_cpp17
-            - build_clang_latest_cpp17
+  build_and_test:
+    jobs:
+    - build_latest_cpp17:
+        matrix:
+          parameters:
+            docker: [gcc, clang]
+            build_type: [Release]


### PR DESCRIPTION
This PR will make CircleCI use the [gcc](https://github.com/teeks99/gcc-ubuntu-docker) and [clang](https://github.com/teeks99/clang-ubuntu-docker) images by teeks99, which are based on Ubuntu, so it's less hassle to set things up (install cmake and ninja).

The gcc and clang jobs are run using a parameterized matrix as well.

Just a note, but `CI` env var is always set in CI services and developer mode is force enabled if the `CI` env var is a true value, i.e. no need to pass `refl-cpp_DEVELOPER_MODE`.

Edit: you should enable running CI on PRs. On CircleCI, you can do this in Project settings > Advanced > Build forked pull requests and Auto-cancel redundant builds.