### PR TITLE
Invoke function with void return type

### DIFF
--- a/test/080-Runtime.hpp
+++ b/test/080-Runtime.hpp
@@ -77,6 +77,7 @@ TEST_CASE( "runtime utils" ) {
 
     SECTION( "invoke" ) {
         REQUIRE( runtime::invoke<int>(Bar{}, "x", 1) == 1 );
+		runtime::invoke<void>(Bar{}, "f");
     }
 
 }


### PR DESCRIPTION
The invoke functionality should be able to work with functions with void return type. Unfortunately one of my use-cases required this, so I've prepared a quick-and-dirty fix for that. I believe this can be achieved with less repetition. 