### PR TITLE
Get display name const vs2019 fix

### DIFF
--- a/include/refl.hpp
+++ b/include/refl.hpp
@@ -204,8 +204,7 @@ namespace refl
             constexpr auto substr() const noexcept
             {
                 static_assert(Pos <= N);
-                //constexpr size_t NewSize = std::min(Count, N - Pos);
-                constexpr size_t NewSize = ( Count < N - Pos ) ? Count : N - Pos;
+                constexpr size_t NewSize = ( Count < N - Pos ) ? Count : N - Pos; //Visual Studio 2019 croaks on std::min
 
                 char buf[NewSize + 1]{};
                 for (size_t i = 0; i < NewSize; i++) {

--- a/include/refl.hpp
+++ b/include/refl.hpp
@@ -204,7 +204,8 @@ namespace refl
             constexpr auto substr() const noexcept
             {
                 static_assert(Pos <= N);
-                constexpr size_t NewSize = std::min(Count, N - Pos);
+                //constexpr size_t NewSize = std::min(Count, N - Pos);
+                constexpr size_t NewSize = ( Count < N - Pos ) ? Count : N - Pos;
 
                 char buf[NewSize + 1]{};
                 for (size_t i = 0; i < NewSize; i++) {

--- a/include/refl.hpp
+++ b/include/refl.hpp
@@ -204,7 +204,7 @@ namespace refl
             constexpr auto substr() const noexcept
             {
                 static_assert(Pos <= N);
-                constexpr size_t NewSize = ( Count < N - Pos ) ? Count : N - Pos; //Visual Studio 2019 croaks on std::min
+                constexpr size_t NewSize = (std::min)(Count, N - Pos);
 
                 char buf[NewSize + 1]{};
                 for (size_t i = 0; i < NewSize; i++) {


### PR DESCRIPTION
This pull request resolves #52.

The issue turned out to be that Visual Studio 2019 (latest version as of this post) does not like the use of `std::min` where it was being used in `refl.hpp`. (EDIT) I had replaced it with simple C code but have subsequently realized that the problem is that the Windows include files don't work with `std::min/max` without the inclusion of `#define NOMINMAX`. So now the change is just to put `std::min` in parentheses, which fixes the problem on Windows without the `#define` and continues to work on other platforms.
