### PR TITLE
Skip over 16/64 items per instantiation of get_t

### DIFF
--- a/include/refl.hpp
+++ b/include/refl.hpp
@@ -702,24 +702,77 @@ namespace refl
 
         namespace detail
         {
-            template <size_t N, typename... Ts>
+
+            template <size_t D, size_t N, typename... Ts>
             struct get;
 
-            template <size_t N>
-            struct get<N>
+            template <size_t D, size_t N>
+            struct get<D, N>
             {
                 static_assert(N > 0, "Missing arguments list for get<N, Ts...>!");
             };
 
             template <size_t N, typename T, typename... Ts>
-            struct get<N, T, Ts...> : public get<N - 1, Ts...>
+            struct get<1, N, T, Ts...> : public get<
+                                             (N > 16 ? (N > 64 ? 64 : 16) : 1),
+                                             N - 1, Ts...>
             {
             };
 
             template <typename T, typename... Ts>
-            struct get<0, T, Ts...>
+            struct get<1, 0, T, Ts...>
             {
                 typedef T type;
+            };
+
+            template <typename T, typename... Ts>
+            struct get<16, 0, T, Ts...>
+            {
+                typedef T type;
+            };
+
+            template <typename T, typename... Ts>
+            struct get<64, 0, T, Ts...>
+            {
+                typedef T type;
+            };
+
+            template <
+                size_t N, typename T0, typename T1, typename T2, typename T3,
+                typename T4, typename T5, typename T6, typename T7, typename T8,
+                typename T9, typename T10, typename T11, typename T12,
+                typename T13, typename T14, typename T15, typename... Ts>
+            struct get<
+                16, N, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+                T13, T14, T15, Ts...> : get<1, N - 16, Ts...>
+            {
+            };
+
+            template <
+                size_t N, typename T0, typename T1, typename T2, typename T3,
+                typename T4, typename T5, typename T6, typename T7, typename T8,
+                typename T9, typename T10, typename T11, typename T12,
+                typename T13, typename T14, typename T15, typename T16,
+                typename T17, typename T18, typename T19, typename T20,
+                typename T21, typename T22, typename T23, typename T24,
+                typename T25, typename T26, typename T27, typename T28,
+                typename T29, typename T30, typename T31, typename T32,
+                typename T33, typename T34, typename T35, typename T36,
+                typename T37, typename T38, typename T39, typename T40,
+                typename T41, typename T42, typename T43, typename T44,
+                typename T45, typename T46, typename T47, typename T48,
+                typename T49, typename T50, typename T51, typename T52,
+                typename T53, typename T54, typename T55, typename T56,
+                typename T57, typename T58, typename T59, typename T60,
+                typename T61, typename T62, typename T63, typename... Ts>
+            struct get<
+                64, N, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+                T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25,
+                T26, T27, T28, T29, T30, T31, T32, T33, T34, T35, T36, T37, T38,
+                T39, T40, T41, T42, T43, T44, T45, T46, T47, T48, T49, T50, T51,
+                T52, T53, T54, T55, T56, T57, T58, T59, T60, T61, T62, T63,
+                Ts...> : get<1, N - 64, Ts...>
+            {
             };
 
             template <size_t N, typename...>
@@ -757,7 +810,7 @@ namespace refl
          * \endcode
          */
         template <size_t N, typename... Ts>
-        struct get<N, type_list<Ts...>> : detail::get<N, Ts...>
+        struct get<N, type_list<Ts...>> : detail::get<1, N, Ts...>
         {
         };
 


### PR DESCRIPTION
This should substantially speed up compile times for many common operations. The large-pod 2x benchmark runs about 6 times faster.