### PR TITLE
compile with llvm's libc++

### DIFF
--- a/include/refl.hpp
+++ b/include/refl.hpp
@@ -34,7 +34,13 @@
 #include <sstream>
 #include <iomanip> // std::quoted
 
-#if defined(__APPLE__)
+#if __has_include(<version>)
+    #include <version>
+#else
+    #include <ciso646>
+#endif
+
+#if defined(__APPLE__) || defined(_LIBCPP_VERSION)
 
 #include <memory>
 #include <complex>


### PR DESCRIPTION
the forward declarations work neither with apple nor with llvm libc++, or emscripten

how to test:
```
cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" -Drefl-cpp_DEVELOPER_MODE=ON ..
```
would not build without the changes alot of:
```
In file included from /home/alex/dev/refl-cpp/test/010-TestCase.cpp:1:
In file included from /home/alex/dev/refl-cpp/test/020-ConstString.hpp:3:
/home/alex/dev/refl-cpp/test/extern/catch2/catch.hpp:5121:33: error: reference to 'shared_ptr' is ambiguous
        using PatternPtr = std::shared_ptr<Pattern>;
                                ^
/usr/bin/../include/c++/v1/__memory/shared_ptr.h:421:59: note: candidate found by name lookup is 'std::__1::shared_ptr'
class _LIBCPP_SHARED_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS shared_ptr
                                                          ^
/home/alex/dev/refl-cpp/include/refl.hpp:52:11: note: candidate found by name lookup is 'std::shared_ptr'
    class shared_ptr;
          ^
```

version will define _LIBCPP_VERSION and similiar
if support for older compilers is important one can change to

```
#if _MSC_VER >= 1922 || __clang_major__ >= 9 || __GNUC__ >= 9
    #include <version>
#else
    #include <ciso646>
#endif
```
